### PR TITLE
feat(issue10): 落地 Claude JSON 统计与 tmux patrol

### DIFF
--- a/docs/reports/260310_10_phase1_json_stats_impl.md
+++ b/docs/reports/260310_10_phase1_json_stats_impl.md
@@ -1,0 +1,116 @@
+# 260310_10_phase1_json_stats_impl
+
+## 背景
+
+根据 Issue #10 `feat: 轻量集成 Claude CLI JSON 协议 + tmux 巡查器`，本轮先落地 Phase 1 最小可用闭环：
+
+- executor 输出从 `text` 升级为 `json`
+- 解析 Claude JSON 结果中的 `session_id`、`usage`、`total_cost_usd`
+- SQLite 增加 `token_usage` 表与 `tasks.last_session_id`
+- 新增 `ccclaw stats` 基础统计命令
+
+本轮不进入 tmux / patrol / journal / resume，保持范围与 Issue 已拍板阶段一致。
+
+## 实现内容
+
+### 1. executor 改为 JSON 结果驱动
+
+修改 `src/internal/executor/executor.go`：
+
+- 调用参数从 `--output-format text` 改为 `--output-format json`
+- stdout/stderr 分离采集，避免 stderr 污染 JSON 解析
+- 新增结构化解析：
+  - `session_id`
+  - `usage.input_tokens`
+  - `usage.output_tokens`
+  - `usage.cache_creation_input_tokens`
+  - `usage.cache_read_input_tokens`
+  - `total_cost_usd`
+- 即使 Claude 返回结构化错误结果，也尽量保留已解析出的 `session_id` 与 token/cost 指标，供后续 Phase 3 恢复能力复用
+
+### 2. task / SQLite 持久化补齐会话与 token 维度
+
+修改 `src/internal/core/task.go` 与 `src/internal/adapters/storage/sqlite.go`：
+
+- `core.Task` 新增 `LastSessionID`
+- 新增 `core.TokenUsage`
+- `tasks` 表新增 `last_session_id`
+- 启动时自动检查并补齐旧库缺失列，避免已有状态库因 schema 演进失效
+- 新增 `token_usage` 表，记录：
+  - `task_id`
+  - `session_id`
+  - input/output/cache token
+  - `cost_usd`
+  - `duration_ms`
+  - `rtk_enabled` 预留字段
+
+### 3. runtime 在成功与失败路径都记录执行指标
+
+修改 `src/internal/app/runtime.go`：
+
+- executor 返回结果后，优先把 `session_id` 回写到 task
+- 只要拿到结构化结果，就写入 `token_usage`
+- 因此即便任务失败，只要 Claude 返回了 JSON 结果，也不会丢失本次 session/token/cost 记录
+
+这一步为后续 Phase 3 的 `--resume` 保留了基础数据。
+
+### 4. 新增 `ccclaw stats`
+
+修改 `src/cmd/ccclaw/main.go` 与 `src/internal/app/runtime.go`：
+
+- 新增 `ccclaw stats`
+- 当前输出聚焦基础历史聚合，避免越过 #12 尚未拍板的 `status/stats` 语义边界
+- 输出包含：
+  - 执行次数
+  - 会话数
+  - input/output/cache token 汇总
+  - 累计成本
+  - 首次/最近记录时间
+  - 最近任务维度的 token 汇总表
+
+## 测试与验证
+
+新增测试：
+
+- `src/internal/executor/executor_test.go`
+  - 验证成功 JSON 解析
+  - 验证结构化错误 JSON 仍保留 `session_id/cost`
+- `src/internal/adapters/storage/sqlite_test.go`
+  - 验证 `last_session_id` 持久化
+  - 验证 `token_usage` 汇总与任务维度统计
+- `src/internal/app/runtime_test.go`
+  - 验证 `ccclaw stats` 输出摘要与任务表
+
+执行验证：
+
+```bash
+/usr/local/go/bin/go test ./...
+```
+
+注意：
+
+- 当前系统默认 `go` 仍是 `/usr/bin/go` -> `go1.19.8`
+- 仓库 `src/go.mod` 为 `go 1.25.7`
+- 因此验证继续使用仓库既有约束中的 `/usr/local/go/bin/go`
+
+## 未纳入本轮的内容
+
+以下内容仍保持在 Issue #10 后续阶段：
+
+- tmux 会话管理
+- `ccclaw patrol`
+- systemd patrol timer/service
+- `--resume` 恢复逻辑
+- prompt 归档
+- journal 生成
+- rtk 前后对比统计
+
+## 结论
+
+本轮已把 Phase 1 的关键底座接通：
+
+- `ccclaw` 不再把 Claude 当成纯文本黑盒
+- 已能沉淀 session/token/cost 基础数据
+- 已有最小可用的 `stats` 命令消费这些数据
+
+后续进入 Phase 2 时，可以直接在此基础上叠加 tmux 巡查与运行态观测，而不需要回头重做数据层。

--- a/docs/reports/260310_10_phase2_tmux_patrol_impl.md
+++ b/docs/reports/260310_10_phase2_tmux_patrol_impl.md
@@ -1,0 +1,165 @@
+# 260310_10_phase2_tmux_patrol_impl
+
+## 背景
+
+在 Phase 1 已完成 Claude JSON 结果解析、`token_usage` 落库和 `ccclaw stats` 基础统计后，Issue #10 的下一阶段是把执行模型从“同步阻塞等待 Claude 退出”升级为“tmux 异步 launch + patrol 巡查收尾”。
+
+本轮目标限定在 Phase 2：
+
+- 新增 tmux 会话管理层
+- `run` 改为优先通过 tmux 启动任务
+- 新增 `ccclaw patrol`
+- 补齐 patrol 的 systemd timer/service
+- 安装与升级链路同步纳入 tmux / patrol
+
+本轮仍不进入 Phase 3 的 `--resume`、prompt 归档、journal、rtk 对比统计。
+
+## 实现内容
+
+### 1. 新增 tmux 管理层
+
+新增 `src/internal/tmux/manager.go`：
+
+- 封装 tmux `Launch / Status / List / CaptureOutput / Kill`
+- 统一解析：
+  - `session_name`
+  - `session_created`
+  - `pane_dead`
+  - `pane_dead_status`
+  - `pane_pid`
+- 对 `no server running` / `can't find session` 做了显式错误收口，便于 runtime 区分“会话缺失”与“命令失败”
+
+### 2. executor 切换为“tmux 优先，缺失时降级同步”
+
+修改 `src/internal/executor/executor.go`：
+
+- `Executor` 新增：
+  - `resultDir`
+  - `tmuxManager`
+- 当本机存在 `tmux` 时：
+  - `Run()` 不再同步等待 Claude 完成
+  - 改为为 task 生成稳定的：
+    - `SessionName`
+    - `LogFile`
+    - `ResultFile`
+  - 通过 tmux 后台 launch：
+    - `pipe-pane` 持续落日志
+    - `bash -lc 'set -o pipefail; ... | tee result.json'`
+  - 返回 `Pending=true`
+- 当本机没有 `tmux` 时：
+  - 自动降级为 Phase 1 的同步执行路径
+
+这保证了：
+
+- 新环境可获得 tmux 巡查能力
+- 旧环境不会因为缺失 tmux 而彻底失去执行能力
+
+### 3. `run` 改为“launch，不收尾”
+
+修改 `src/internal/app/runtime.go`：
+
+- `run` 对于 tmux 路径：
+  - 把任务置为 `RUNNING`
+  - 记录 `STARTED`
+  - 记录“已挂入 tmux 会话”的事件
+  - 不再立即写 DONE/FAILED
+- 同步降级路径仍保留原先的即时收尾逻辑
+
+因此现在的运行模型变为：
+
+1. `ccclaw run` 发射任务
+2. 任务在 tmux 会话中后台执行
+3. `ccclaw patrol` 负责回收结果并更新最终状态
+
+### 4. 新增 `ccclaw patrol`
+
+修改 `src/cmd/ccclaw/main.go` 与 `src/internal/app/runtime.go`：
+
+- 新增 `ccclaw patrol`
+- 巡查逻辑按运行中任务逐个匹配对应 tmux session
+
+已落地行为：
+
+1. session 已结束
+- 读取 result JSON
+- 解析结果
+- 写入 `token_usage`
+- 更新 task 为 `DONE` 或 `FAILED`
+- 清理 tmux session
+
+2. session 运行中但超时
+- 抓取最近 pane 输出
+- 终止 tmux session
+- 将任务记为 `DEAD`
+
+3. session 丢失且没有结果文件
+- 将任务记为 `DEAD`
+
+4. session 接近超时
+- 写入 `WARNING` 事件
+
+5. 巡查孤儿 session
+- 对没有对应运行中 task 的 `ccclaw-*` session 直接清理
+
+### 5. doctor / systemd / install 同步收口
+
+本轮把外围链路一并补齐，避免“代码依赖 tmux，安装却不知道”：
+
+- `doctor` 新增 `tmux CLI` 检查
+- user systemd 单元集扩充为：
+  - `ccclaw-ingest.*`
+  - `ccclaw-run.*`
+  - `ccclaw-patrol.*`
+- `src/dist/install.sh`
+  - preflight 与依赖安装把 `tmux` 纳入必装工具
+  - 安装摘要与后续启用提示改为包含 `ccclaw-patrol.timer`
+- `src/dist/upgrade.sh`
+  - 重启提示改为同时包含 `ccclaw-patrol.timer`
+- `src/ops/systemd/` 与 `src/dist/ops/systemd/`
+  - 新增 `ccclaw-patrol.service`
+  - 新增 `ccclaw-patrol.timer`
+
+## 测试与验证
+
+新增/扩展测试：
+
+- `src/internal/executor/executor_test.go`
+  - 保留同步 JSON 解析测试
+  - 新增 tmux launch 返回 `Pending` 测试
+- `src/internal/app/runtime_test.go`
+  - 新增 dead tmux session 经 `patrol` 收尾为 `DONE` 的测试
+- 原有 SQLite / stats 测试继续通过
+
+执行验证：
+
+```bash
+/usr/local/go/bin/go test ./...
+make -C src dist-sync GO=/usr/local/go/bin/go GOFMT=/usr/local/go/bin/gofmt
+bash src/tests/install_regression.sh
+```
+
+结果：
+
+- Go 单测全部通过
+- `dist/ops` 已同步新增 patrol unit
+- `install.sh` 回归测试全部通过
+
+## 本轮未做
+
+仍留在 Phase 3 之后：
+
+- `--resume`
+- 基于 `last_session_id` 的恢复重试
+- prompt 归档
+- `ccclaw journal`
+- rtk 前后对比统计
+
+## 结论
+
+本轮已把 #10 的 Phase 2 核心增强落地：
+
+- `ccclaw run` 已具备 tmux 异步执行能力
+- `ccclaw patrol` 已能完成任务收尾与超时巡查
+- 安装、升级、systemd、doctor 已和 tmux/patrol 依赖保持一致
+
+后续进入 Phase 3 时，可以直接围绕现有 `last_session_id` 和 patrol 数据面追加恢复与 journal，不需要再回头重构执行模型。

--- a/src/cmd/ccclaw/main.go
+++ b/src/cmd/ccclaw/main.go
@@ -82,6 +82,30 @@ func newRootCmd() *cobra.Command {
 	})
 
 	rootCmd.AddCommand(&cobra.Command{
+		Use:   "stats",
+		Short: "查看 token 使用统计",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rt, err := app.NewRuntime(configPath, envFile)
+			if err != nil {
+				return err
+			}
+			return rt.Stats(os.Stdout)
+		},
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "patrol",
+		Short: "巡查 tmux 会话与运行中任务",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rt, err := app.NewRuntime(configPath, envFile)
+			if err != nil {
+				return err
+			}
+			return rt.Patrol(cmd.Context(), os.Stdout)
+		},
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
 		Use:   "doctor",
 		Short: "执行环境与部署健康检查",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/src/dist/install.sh
+++ b/src/dist/install.sh
@@ -594,7 +594,7 @@ INFO
 print_flow() {
   cat <<FLOW
 == 计划执行流程 ==
-1. 探查现有环境：claude / gh / rg / sqlite3 / rtk / git / node / npm / uv / systemd --user
+1. 探查现有环境：claude / gh / rg / sqlite3 / tmux / rtk / git / node / npm / uv / systemd --user
 2. 决定程序目录与本体仓库目录：
    - 程序目录: $APP_DIR
    - 本体仓库: $HOME_REPO
@@ -622,7 +622,7 @@ print_flow() {
    - $APP_DIR/upgrade.sh
    - $APP_DIR/ops/*
 8. 安装基础工具：
-   - 必装: git gh rg sqlite3 curl wget golang
+   - 必装: git gh rg sqlite3 tmux curl wget golang
    - 能力工具: node npm uv
    - token 优化: rtk
 9. 若 Claude 已可用：
@@ -738,7 +738,7 @@ validate_inputs() {
 ensure_system_packages() {
   local missing_tools=()
   local missing_packages=()
-  local required=(git gh rg sqlite3 curl wget)
+  local required=(git gh rg sqlite3 tmux curl wget)
   local optional=(node npm uv)
   for tool in "${required[@]}"; do
     if ! have "$tool"; then
@@ -999,6 +999,8 @@ create_user_systemd_units() {
   local ingest_timer="$SYSTEMD_USER_DIR/ccclaw-ingest.timer"
   local run_service="$SYSTEMD_USER_DIR/ccclaw-run.service"
   local run_timer="$SYSTEMD_USER_DIR/ccclaw-run.timer"
+  local patrol_service="$SYSTEMD_USER_DIR/ccclaw-patrol.service"
+  local patrol_timer="$SYSTEMD_USER_DIR/ccclaw-patrol.timer"
   if [[ "$SCHEDULER_EFFECTIVE" != "systemd" ]]; then
     log "跳过 user systemd 单元部署；当前调度模式: $SCHEDULER_EFFECTIVE"
     return 0
@@ -1048,6 +1050,28 @@ Description=Run ccclaw worker every 10 minutes
 OnCalendar=*:0/10
 Persistent=true
 Unit=ccclaw-run.service
+
+[Install]
+WantedBy=timers.target
+UNIT
+  cat > "$patrol_service" <<UNIT
+[Unit]
+Description=ccclaw patrol service
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=$APP_DIR
+ExecStart=$APP_DIR/bin/ccclaw patrol --config $CONFIG_FILE --env-file $ENV_FILE
+UNIT
+  cat > "$patrol_timer" <<UNIT
+[Unit]
+Description=Run ccclaw patrol every 2 minutes
+
+[Timer]
+OnCalendar=*:0/2
+Persistent=true
+Unit=ccclaw-patrol.service
 
 [Install]
 WantedBy=timers.target
@@ -1332,7 +1356,7 @@ print_summary() {
     systemd)
       scheduler_step_6="6. 按需启用用户定时器:
    systemctl --user daemon-reload
-   systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer"
+   systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"
       scheduler_step_7="7. 若后续环境不适合 systemd --user，可改为手工写入 crontab 样板:
    */5 * * * * $APP_DIR/bin/ccclaw ingest --config $CONFIG_FILE --env-file $ENV_FILE
    */10 * * * * $APP_DIR/bin/ccclaw run --config $CONFIG_FILE --env-file $ENV_FILE"
@@ -1343,7 +1367,7 @@ print_summary() {
    */10 * * * * $APP_DIR/bin/ccclaw run --config $CONFIG_FILE --env-file $ENV_FILE"
       scheduler_step_7="7. 若后续切回 systemd --user，请先执行:
    systemctl --user daemon-reload
-   systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer"
+   systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"
       ;;
     none|*)
       scheduler_step_6="6. 当前调度模式为 none；如需后台调度，可手工写入 crontab:
@@ -1351,7 +1375,7 @@ print_summary() {
    */10 * * * * $APP_DIR/bin/ccclaw run --config $CONFIG_FILE --env-file $ENV_FILE"
       scheduler_step_7="7. 若后续修复好 user systemd，再执行:
    systemctl --user daemon-reload
-   systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer"
+   systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"
       ;;
   esac
   cat <<MSG
@@ -1378,6 +1402,8 @@ $result_title
   - ccclaw-ingest.timer
   - ccclaw-run.service
   - ccclaw-run.timer
+  - ccclaw-patrol.service
+  - ccclaw-patrol.timer
 - crontab: 默认不自动写入，仅提供样板
 
 建议下一步

--- a/src/dist/ops/systemd/ccclaw-patrol.service
+++ b/src/dist/ops/systemd/ccclaw-patrol.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=ccclaw patrol service (user)
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.ccclaw
+ExecStart=%h/.ccclaw/bin/ccclaw patrol --config %h/.ccclaw/ops/config/config.toml --env-file %h/.ccclaw/.env

--- a/src/dist/ops/systemd/ccclaw-patrol.timer
+++ b/src/dist/ops/systemd/ccclaw-patrol.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run ccclaw patrol every 2 minutes (user)
+
+[Timer]
+OnCalendar=*:0/2
+Persistent=true
+Unit=ccclaw-patrol.service
+
+[Install]
+WantedBy=timers.target

--- a/src/dist/upgrade.sh
+++ b/src/dist/upgrade.sh
@@ -26,4 +26,4 @@ if [[ "$REFRESH_CLAUDE_ASSETS" == "1" ]]; then
   echo "plugins/skills 刷新依赖 install.sh 中的 Claude 资产配置逻辑；若 Claude 当前不可用，此步会被跳过。"
 fi
 
-echo "升级完成。若使用 user systemd，请执行: systemctl --user daemon-reload && systemctl --user restart ccclaw-ingest.timer ccclaw-run.timer"
+echo "升级完成。若使用 user systemd，请执行: systemctl --user daemon-reload && systemctl --user restart ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"

--- a/src/internal/adapters/storage/sqlite.go
+++ b/src/internal/adapters/storage/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/41490/ccclaw/internal/core"
@@ -14,6 +15,42 @@ import (
 
 type Store struct {
 	db *sql.DB
+}
+
+type TokenUsageRecord struct {
+	TaskID     string
+	SessionID  string
+	Usage      core.TokenUsage
+	CostUSD    float64
+	DurationMS int64
+	RTKEnabled bool
+	RecordedAt time.Time
+}
+
+type TokenStatsSummary struct {
+	Runs         int
+	Sessions     int
+	InputTokens  int
+	OutputTokens int
+	CacheCreate  int
+	CacheRead    int
+	CostUSD      float64
+	FirstUsedAt  time.Time
+	LastUsedAt   time.Time
+}
+
+type TaskTokenStat struct {
+	TaskID         string
+	IssueNumber    int
+	IssueTitle     string
+	LastSessionID  string
+	Runs           int
+	InputTokens    int
+	OutputTokens   int
+	CacheCreate    int
+	CacheRead      int
+	CostUSD        float64
+	LastRecordedAt time.Time
 }
 
 func Open(path string) (*Store, error) {
@@ -42,7 +79,7 @@ func (s *Store) Ping() error {
 
 func (s *Store) GetByIdempotency(idempotencyKey string) (*core.Task, error) {
 	row := s.db.QueryRow(`
-		SELECT task_id, idempotency_key, control_repo, target_repo, issue_number, issue_title, issue_body,
+		SELECT task_id, idempotency_key, control_repo, target_repo, last_session_id, issue_number, issue_title, issue_body,
 		issue_author, issue_author_permission, labels, intent, risk_level, approved, approval_command,
 		approval_actor, approval_comment_id, state, retry_count, error_msg, report_path, created_at, updated_at
 		FROM tasks WHERE idempotency_key = ?
@@ -62,11 +99,13 @@ func (s *Store) UpsertTask(task *core.Task) error {
 	task.UpdatedAt = now
 	_, err = s.db.Exec(`
 		INSERT INTO tasks (
-			task_id, idempotency_key, control_repo, target_repo, issue_number, issue_title, issue_body,
+			task_id, idempotency_key, control_repo, target_repo, last_session_id, issue_number, issue_title, issue_body,
 			issue_author, issue_author_permission, labels, intent, risk_level, approved, approval_command,
 			approval_actor, approval_comment_id, state, retry_count, error_msg, report_path, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(task_id) DO UPDATE SET
+			target_repo = excluded.target_repo,
+			last_session_id = excluded.last_session_id,
 			issue_title = excluded.issue_title,
 			issue_body = excluded.issue_body,
 			issue_author = excluded.issue_author,
@@ -84,7 +123,7 @@ func (s *Store) UpsertTask(task *core.Task) error {
 			report_path = excluded.report_path,
 			updated_at = excluded.updated_at
 	`,
-		task.TaskID, task.IdempotencyKey, task.ControlRepo, task.TargetRepo, task.IssueNumber, task.IssueTitle, task.IssueBody,
+		task.TaskID, task.IdempotencyKey, task.ControlRepo, task.TargetRepo, task.LastSessionID, task.IssueNumber, task.IssueTitle, task.IssueBody,
 		task.IssueAuthor, task.IssueAuthorPermission, string(labels), string(task.Intent), string(task.RiskLevel), boolToInt(task.Approved), task.ApprovalCommand,
 		task.ApprovalActor, task.ApprovalCommentID, string(task.State), task.RetryCount, task.ErrorMsg, task.ReportPath, task.CreatedAt, task.UpdatedAt,
 	)
@@ -102,9 +141,150 @@ func (s *Store) AppendEvent(taskID string, eventType core.EventType, detail stri
 	return nil
 }
 
+func (s *Store) RecordTokenUsage(record TokenUsageRecord) error {
+	recordedAt := record.RecordedAt
+	if recordedAt.IsZero() {
+		recordedAt = time.Now()
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO token_usage (
+			task_id, session_id, input_tokens, output_tokens, cache_create, cache_read,
+			cost_usd, duration_ms, rtk_enabled, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		record.TaskID,
+		record.SessionID,
+		record.Usage.InputTokens,
+		record.Usage.OutputTokens,
+		record.Usage.CacheCreationInputTokens,
+		record.Usage.CacheReadInputTokens,
+		record.CostUSD,
+		record.DurationMS,
+		boolToInt(record.RTKEnabled),
+		recordedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("写入 token 使用记录失败: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) TokenStats() (*TokenStatsSummary, error) {
+	row := s.db.QueryRow(`
+		SELECT
+			COUNT(*) AS runs,
+			COUNT(DISTINCT NULLIF(session_id, '')) AS sessions,
+			COALESCE(SUM(input_tokens), 0),
+			COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(cache_create), 0),
+			COALESCE(SUM(cache_read), 0),
+			COALESCE(SUM(cost_usd), 0),
+			COALESCE(MIN(created_at), ''),
+			COALESCE(MAX(created_at), '')
+		FROM token_usage
+	`)
+	var (
+		summary   TokenStatsSummary
+		firstUsed string
+		lastUsed  string
+	)
+	if err := row.Scan(
+		&summary.Runs,
+		&summary.Sessions,
+		&summary.InputTokens,
+		&summary.OutputTokens,
+		&summary.CacheCreate,
+		&summary.CacheRead,
+		&summary.CostUSD,
+		&firstUsed,
+		&lastUsed,
+	); err != nil {
+		return nil, fmt.Errorf("读取 token 汇总失败: %w", err)
+	}
+	if firstUsed != "" {
+		parsed, err := parseSQLiteTime(firstUsed)
+		if err != nil {
+			return nil, err
+		}
+		summary.FirstUsedAt = parsed
+	}
+	if lastUsed != "" {
+		parsed, err := parseSQLiteTime(lastUsed)
+		if err != nil {
+			return nil, err
+		}
+		summary.LastUsedAt = parsed
+	}
+	return &summary, nil
+}
+
+func (s *Store) TaskTokenStats(limit int) ([]TaskTokenStat, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(`
+		SELECT
+			t.task_id,
+			t.issue_number,
+			t.issue_title,
+			t.last_session_id,
+			COUNT(u.id) AS runs,
+			COALESCE(SUM(u.input_tokens), 0),
+			COALESCE(SUM(u.output_tokens), 0),
+			COALESCE(SUM(u.cache_create), 0),
+			COALESCE(SUM(u.cache_read), 0),
+			COALESCE(SUM(u.cost_usd), 0),
+			COALESCE(MAX(u.created_at), '')
+		FROM token_usage u
+		JOIN tasks t ON t.task_id = u.task_id
+		GROUP BY t.task_id, t.issue_number, t.issue_title, t.last_session_id
+		ORDER BY MAX(u.created_at) DESC, t.issue_number DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("读取任务 token 统计失败: %w", err)
+	}
+	defer rows.Close()
+
+	var stats []TaskTokenStat
+	for rows.Next() {
+		var (
+			item     TaskTokenStat
+			lastUsed string
+		)
+		if err := rows.Scan(
+			&item.TaskID,
+			&item.IssueNumber,
+			&item.IssueTitle,
+			&item.LastSessionID,
+			&item.Runs,
+			&item.InputTokens,
+			&item.OutputTokens,
+			&item.CacheCreate,
+			&item.CacheRead,
+			&item.CostUSD,
+			&lastUsed,
+		); err != nil {
+			return nil, fmt.Errorf("扫描任务 token 统计失败: %w", err)
+		}
+		if lastUsed != "" {
+			parsed, err := parseSQLiteTime(lastUsed)
+			if err != nil {
+				return nil, err
+			}
+			item.LastRecordedAt = parsed
+		}
+		stats = append(stats, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历任务 token 统计失败: %w", err)
+	}
+	return stats, nil
+}
+
 func (s *Store) ListTasks() ([]*core.Task, error) {
 	rows, err := s.db.Query(`
-		SELECT task_id, idempotency_key, control_repo, target_repo, issue_number, issue_title, issue_body,
+		SELECT task_id, idempotency_key, control_repo, target_repo, last_session_id, issue_number, issue_title, issue_body,
 		issue_author, issue_author_permission, labels, intent, risk_level, approved, approval_command,
 		approval_actor, approval_comment_id, state, retry_count, error_msg, report_path, created_at, updated_at
 		FROM tasks ORDER BY updated_at DESC, issue_number DESC
@@ -130,7 +310,7 @@ func (s *Store) ListTasks() ([]*core.Task, error) {
 
 func (s *Store) ListRunnable(limit int) ([]*core.Task, error) {
 	rows, err := s.db.Query(`
-		SELECT task_id, idempotency_key, control_repo, target_repo, issue_number, issue_title, issue_body,
+		SELECT task_id, idempotency_key, control_repo, target_repo, last_session_id, issue_number, issue_title, issue_body,
 		issue_author, issue_author_permission, labels, intent, risk_level, approved, approval_command,
 		approval_actor, approval_comment_id, state, retry_count, error_msg, report_path, created_at, updated_at
 		FROM tasks
@@ -157,6 +337,34 @@ func (s *Store) ListRunnable(limit int) ([]*core.Task, error) {
 	return tasks, nil
 }
 
+func (s *Store) ListRunning() ([]*core.Task, error) {
+	rows, err := s.db.Query(`
+		SELECT task_id, idempotency_key, control_repo, target_repo, last_session_id, issue_number, issue_title, issue_body,
+		issue_author, issue_author_permission, labels, intent, risk_level, approved, approval_command,
+		approval_actor, approval_comment_id, state, retry_count, error_msg, report_path, created_at, updated_at
+		FROM tasks
+		WHERE state = 'RUNNING'
+		ORDER BY updated_at ASC, issue_number ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("读取运行中任务失败: %w", err)
+	}
+	defer rows.Close()
+
+	var tasks []*core.Task
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历运行中任务失败: %w", err)
+	}
+	return tasks, nil
+}
+
 func (s *Store) init() error {
 	ddl := []string{
 		`CREATE TABLE IF NOT EXISTS tasks (
@@ -164,6 +372,7 @@ func (s *Store) init() error {
 			idempotency_key TEXT UNIQUE NOT NULL,
 			control_repo TEXT NOT NULL,
 			target_repo TEXT NOT NULL,
+			last_session_id TEXT NOT NULL DEFAULT '',
 			issue_number INTEGER NOT NULL,
 			issue_title TEXT,
 			issue_body TEXT,
@@ -191,12 +400,30 @@ func (s *Store) init() error {
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			FOREIGN KEY(task_id) REFERENCES tasks(task_id)
 		)`,
+		`CREATE TABLE IF NOT EXISTS token_usage (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			task_id TEXT NOT NULL,
+			session_id TEXT,
+			input_tokens INTEGER DEFAULT 0,
+			output_tokens INTEGER DEFAULT 0,
+			cache_create INTEGER DEFAULT 0,
+			cache_read INTEGER DEFAULT 0,
+			cost_usd REAL DEFAULT 0,
+			duration_ms INTEGER DEFAULT 0,
+			rtk_enabled INTEGER DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY(task_id) REFERENCES tasks(task_id)
+		)`,
 		`CREATE INDEX IF NOT EXISTS idx_tasks_state_updated_at ON tasks(state, updated_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_token_usage_task_created_at ON token_usage(task_id, created_at DESC)`,
 	}
 	for _, stmt := range ddl {
 		if _, err := s.db.Exec(stmt); err != nil {
 			return fmt.Errorf("初始化 SQLite 表失败: %w", err)
 		}
+	}
+	if err := s.ensureTaskColumn("last_session_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
 	}
 	return nil
 }
@@ -215,7 +442,7 @@ func scanTask(row scanner) (*core.Task, error) {
 		approved   int
 	)
 	if err := row.Scan(
-		&task.TaskID, &task.IdempotencyKey, &task.ControlRepo, &task.TargetRepo, &task.IssueNumber, &task.IssueTitle, &task.IssueBody,
+		&task.TaskID, &task.IdempotencyKey, &task.ControlRepo, &task.TargetRepo, &task.LastSessionID, &task.IssueNumber, &task.IssueTitle, &task.IssueBody,
 		&task.IssueAuthor, &task.IssueAuthorPermission, &labelsJSON, &intent, &risk, &approved, &task.ApprovalCommand,
 		&task.ApprovalActor, &task.ApprovalCommentID, &state, &task.RetryCount, &task.ErrorMsg, &task.ReportPath, &task.CreatedAt, &task.UpdatedAt,
 	); err != nil {
@@ -232,6 +459,58 @@ func scanTask(row scanner) (*core.Task, error) {
 	task.State = core.State(state)
 	task.Approved = approved == 1
 	return &task, nil
+}
+
+func (s *Store) ensureTaskColumn(name, columnDef string) error {
+	rows, err := s.db.Query(`PRAGMA table_info(tasks)`)
+	if err != nil {
+		return fmt.Errorf("读取 tasks 表结构失败: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid        int
+			columnName string
+			columnType string
+			notNull    int
+			defaultVal any
+			pk         int
+		)
+		if err := rows.Scan(&cid, &columnName, &columnType, &notNull, &defaultVal, &pk); err != nil {
+			return fmt.Errorf("扫描 tasks 表结构失败: %w", err)
+		}
+		if columnName == name {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("遍历 tasks 表结构失败: %w", err)
+	}
+	if _, err := s.db.Exec(fmt.Sprintf("ALTER TABLE tasks ADD COLUMN %s %s", name, columnDef)); err != nil {
+		return fmt.Errorf("补充 tasks.%s 字段失败: %w", name, err)
+	}
+	return nil
+}
+
+func parseSQLiteTime(value string) (time.Time, error) {
+	if idx := strings.Index(value, " m="); idx >= 0 {
+		value = value[:idx]
+	}
+	layouts := []string{
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04:05 -0700 MST",
+		time.RFC3339Nano,
+	}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("解析 SQLite 时间失败: %s", value)
 }
 
 func boolToInt(v bool) int {

--- a/src/internal/adapters/storage/sqlite_test.go
+++ b/src/internal/adapters/storage/sqlite_test.go
@@ -3,38 +3,80 @@ package storage
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/41490/ccclaw/internal/core"
 )
 
-func TestUpsertAndList(t *testing.T) {
+func TestStorePersistsLastSessionIDAndTokenStats(t *testing.T) {
 	store, err := Open(filepath.Join(t.TempDir(), "state.db"))
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("打开 store 失败: %v", err)
 	}
 	defer store.Close()
 
 	task := &core.Task{
-		TaskID:         core.TaskID(3),
-		IdempotencyKey: core.IdempotencyKey(3),
+		TaskID:         "10#body",
+		IdempotencyKey: "10#body",
 		ControlRepo:    "41490/ccclaw",
 		TargetRepo:     "41490/ccclaw",
-		IssueNumber:    3,
-		IssueTitle:     "phase0",
-		IssueAuthor:    "ZoomQuiet",
+		LastSessionID:  "sess-10",
+		IssueNumber:    10,
+		IssueTitle:     "phase1 stats",
 		Labels:         []string{"ccclaw"},
 		Intent:         core.IntentResearch,
 		RiskLevel:      core.RiskLow,
-		State:          core.StateNew,
+		State:          core.StateDone,
 	}
 	if err := store.UpsertTask(task); err != nil {
-		t.Fatal(err)
+		t.Fatalf("写入任务失败: %v", err)
 	}
-	tasks, err := store.ListTasks()
+	if err := store.RecordTokenUsage(TokenUsageRecord{
+		TaskID:    task.TaskID,
+		SessionID: "sess-10",
+		Usage: core.TokenUsage{
+			InputTokens:              100,
+			OutputTokens:             40,
+			CacheCreationInputTokens: 10,
+			CacheReadInputTokens:     5,
+		},
+		CostUSD:    0.42,
+		DurationMS: 9000,
+		RecordedAt: time.Date(2026, 3, 10, 10, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("写入 token 记录失败: %v", err)
+	}
+
+	loaded, err := store.GetByIdempotency(task.IdempotencyKey)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("读取任务失败: %v", err)
 	}
-	if len(tasks) != 1 {
-		t.Fatalf("expected 1 task, got %d", len(tasks))
+	if loaded == nil || loaded.LastSessionID != "sess-10" {
+		t.Fatalf("unexpected task session: %#v", loaded)
+	}
+
+	summary, err := store.TokenStats()
+	if err != nil {
+		t.Fatalf("读取统计失败: %v", err)
+	}
+	if summary.Runs != 1 || summary.Sessions != 1 {
+		t.Fatalf("unexpected summary counts: %#v", summary)
+	}
+	if summary.InputTokens != 100 || summary.OutputTokens != 40 {
+		t.Fatalf("unexpected summary tokens: %#v", summary)
+	}
+	if summary.CostUSD != 0.42 {
+		t.Fatalf("unexpected summary cost: %#v", summary)
+	}
+
+	stats, err := store.TaskTokenStats(10)
+	if err != nil {
+		t.Fatalf("读取任务维度统计失败: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("unexpected stats count: %d", len(stats))
+	}
+	if stats[0].IssueNumber != 10 || stats[0].LastSessionID != "sess-10" {
+		t.Fatalf("unexpected task stat: %#v", stats[0])
 	}
 }

--- a/src/internal/app/runtime.go
+++ b/src/internal/app/runtime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/41490/ccclaw/internal/core"
 	"github.com/41490/ccclaw/internal/executor"
 	"github.com/41490/ccclaw/internal/memory"
+	"github.com/41490/ccclaw/internal/tmux"
 )
 
 type Runtime struct {
@@ -126,33 +127,177 @@ func (rt *Runtime) Run(ctx context.Context, limit int) error {
 		_ = rt.store.AppendEvent(fresh.TaskID, core.EventStarted, "开始执行任务")
 
 		result, runErr := execEngine.Run(ctx, target.LocalPath, fresh.TaskID, prompt)
-		if runErr != nil {
-			fresh.RetryCount++
-			fresh.ErrorMsg = runErr.Error()
-			fresh.State = core.StateFailed
-			eventType := core.EventFailed
-			if fresh.RetryCount >= core.MaxRetry {
-				fresh.State = core.StateDead
-				eventType = core.EventDead
+		if result != nil && result.Pending {
+			_ = rt.store.AppendEvent(fresh.TaskID, core.EventUpdated, fmt.Sprintf("任务已挂入 tmux 会话 %s", result.SessionName))
+			continue
+		}
+		if result != nil {
+			if result.SessionID != "" {
+				fresh.LastSessionID = result.SessionID
 			}
-			if err := rt.store.UpsertTask(fresh); err != nil {
+		}
+		if err := rt.finishTaskExecution(fresh, result, runErr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rt *Runtime) Patrol(ctx context.Context, out io.Writer) error {
+	defer rt.store.Close()
+	execEngine, err := rt.newExecutor()
+	if err != nil {
+		return err
+	}
+	manager := execEngine.TMux()
+	if manager == nil {
+		_, _ = fmt.Fprintln(out, "当前未启用 tmux，会话巡查已跳过")
+		return nil
+	}
+
+	timeout := execEngine.Timeout()
+	runningTasks, err := rt.store.ListRunning()
+	if err != nil {
+		return err
+	}
+	sessions, err := manager.List("ccclaw-")
+	if err != nil {
+		return err
+	}
+	sessionMap := make(map[string]tmux.SessionStatus, len(sessions))
+	for _, session := range sessions {
+		sessionMap[session.Name] = session
+	}
+
+	var (
+		completed int
+		timedOut  int
+		warnings  int
+		orphaned  int
+	)
+	taskSessions := make(map[string]struct{}, len(runningTasks))
+	for _, task := range runningTasks {
+		artifacts := execEngine.ArtifactPaths(task.TaskID)
+		taskSessions[artifacts.SessionName] = struct{}{}
+		status, exists := sessionMap[artifacts.SessionName]
+		if !exists {
+			if handled, err := rt.finalizeMissingSession(task, execEngine); err != nil {
+				return err
+			} else if handled {
+				completed++
+				continue
+			}
+			if err := rt.markTaskDead(task, fmt.Sprintf("tmux 会话 %s 已丢失，且未找到结果文件", artifacts.SessionName), artifacts.LogFile); err != nil {
 				return err
 			}
-			_ = rt.store.AppendEvent(fresh.TaskID, eventType, fresh.ErrorMsg)
-			_ = rt.rep.ReportFailure(fresh)
+			timedOut++
+			continue
+		}
+		if status.PaneDead {
+			if err := rt.finalizePatrolSession(task, execEngine, status); err != nil {
+				return err
+			}
+			completed++
+			if killErr := manager.Kill(status.Name); killErr != nil {
+				_ = rt.store.AppendEvent(task.TaskID, core.EventWarning, fmt.Sprintf("清理 tmux 会话失败: %v", killErr))
+			}
 			continue
 		}
 
-		fresh.State = core.StateDone
-		fresh.ErrorMsg = ""
-		fresh.ReportPath = filepath.ToSlash(filepath.Join("docs", "reports", core.SafeReportFileName(time.Now(), fresh.IssueNumber, fresh.IssueTitle)))
-		if err := rt.store.UpsertTask(fresh); err != nil {
-			return err
+		runningFor := time.Since(status.CreatedAt)
+		if timeout > 0 && runningFor >= timeout {
+			tail, _ := manager.CaptureOutput(status.Name, 80)
+			if killErr := manager.Kill(status.Name); killErr != nil {
+				return fmt.Errorf("终止超时 tmux 会话失败: %w", killErr)
+			}
+			reason := fmt.Sprintf("tmux 会话 %s 已运行 %s，超过超时阈值 %s", status.Name, runningFor.Round(time.Second), timeout)
+			if tail != "" {
+				reason += "\n最后输出:\n" + tail
+			}
+			if err := rt.markTaskDead(task, reason, artifacts.LogFile); err != nil {
+				return err
+			}
+			timedOut++
+			continue
 		}
-		_ = rt.store.AppendEvent(fresh.TaskID, core.EventDone, "任务执行完成")
-		_ = rt.rep.ReportSuccess(fresh, result.Duration, result.LogFile)
+		if timeout > 0 && runningFor >= timeout*8/10 {
+			_ = rt.store.AppendEvent(task.TaskID, core.EventWarning, fmt.Sprintf("tmux 会话 %s 已运行 %s，接近超时阈值 %s", status.Name, runningFor.Round(time.Second), timeout))
+			warnings++
+		}
 	}
+
+	for _, session := range sessions {
+		if _, exists := taskSessions[session.Name]; exists {
+			continue
+		}
+		if err := manager.Kill(session.Name); err != nil {
+			return fmt.Errorf("清理孤儿 tmux 会话失败: %w", err)
+		}
+		orphaned++
+	}
+
+	_, _ = fmt.Fprintf(out, "巡查完成: completed=%d timeout=%d warning=%d orphaned=%d running=%d\n", completed, timedOut, warnings, orphaned, len(runningTasks))
+	_ = ctx
 	return nil
+}
+
+func (rt *Runtime) Stats(out io.Writer) error {
+	defer rt.store.Close()
+	summary, err := rt.store.TokenStats()
+	if err != nil {
+		return err
+	}
+	if summary.Runs == 0 {
+		_, _ = fmt.Fprintln(out, "暂无 token 使用记录")
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "执行次数: %d\n", summary.Runs)
+	_, _ = fmt.Fprintf(out, "会话数: %d\n", summary.Sessions)
+	_, _ = fmt.Fprintf(out, "输入 tokens: %d\n", summary.InputTokens)
+	_, _ = fmt.Fprintf(out, "输出 tokens: %d\n", summary.OutputTokens)
+	_, _ = fmt.Fprintf(out, "缓存创建 tokens: %d\n", summary.CacheCreate)
+	_, _ = fmt.Fprintf(out, "缓存命中 tokens: %d\n", summary.CacheRead)
+	_, _ = fmt.Fprintf(out, "累计成本(USD): %.4f\n", summary.CostUSD)
+	if !summary.FirstUsedAt.IsZero() {
+		_, _ = fmt.Fprintf(out, "首次记录: %s\n", summary.FirstUsedAt.Format(time.RFC3339))
+	}
+	if !summary.LastUsedAt.IsZero() {
+		_, _ = fmt.Fprintf(out, "最近记录: %s\n", summary.LastUsedAt.Format(time.RFC3339))
+	}
+	stats, err := rt.store.TaskTokenStats(20)
+	if err != nil {
+		return err
+	}
+	if len(stats) == 0 {
+		return nil
+	}
+	_, _ = fmt.Fprintln(out)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ISSUE\tRUNS\tINPUT\tOUTPUT\tCACHE_CREATE\tCACHE_READ\tCOST_USD\tSESSION\tTITLE")
+	for _, item := range stats {
+		title := item.IssueTitle
+		if len(title) > 40 {
+			title = title[:37] + "..."
+		}
+		sessionID := item.LastSessionID
+		if sessionID == "" {
+			sessionID = "-"
+		}
+		_, _ = fmt.Fprintf(
+			w,
+			"#%d\t%d\t%d\t%d\t%d\t%d\t%.4f\t%s\t%s\n",
+			item.IssueNumber,
+			item.Runs,
+			item.InputTokens,
+			item.OutputTokens,
+			item.CacheCreate,
+			item.CacheRead,
+			item.CostUSD,
+			sessionID,
+			title,
+		)
+	}
+	return w.Flush()
 }
 
 func (rt *Runtime) Status(out io.Writer) error {
@@ -243,6 +388,7 @@ func (rt *Runtime) Doctor(ctx context.Context, out io.Writer) error {
 		{name: "Go 工具链", run: func() (string, error) { return commandVersion("go", "version") }},
 		{name: "sudo 无口令", run: rt.checkPasswordlessSudo},
 		{name: "rtk CLI", run: func() (string, error) { return commandVersion("rtk", "--version") }},
+		{name: "tmux CLI", run: func() (string, error) { return commandVersion("tmux", "-V") }},
 		{name: "rg CLI", run: func() (string, error) { return commandVersion("rg", "--version") }},
 		{name: "sqlite3 CLI", run: func() (string, error) { return commandVersion("sqlite3", "--version") }},
 		{name: "git CLI", run: func() (string, error) { return commandVersion("git", "--version") }},
@@ -345,7 +491,7 @@ func (rt *Runtime) syncIssue(ctx context.Context, issue github.Issue, fromRun bo
 		}
 		_ = rt.store.AppendEvent(existing.TaskID, eventType, detail)
 		if existing.State == core.StateBlocked && !fromRun {
-			_ = rt.rep.ReportBlocked(existing, blockReasonText(blockReasons))
+			rt.reportBlocked(existing, blockReasonText(blockReasons))
 		}
 		return nil
 	}
@@ -358,7 +504,7 @@ func (rt *Runtime) syncIssue(ctx context.Context, issue github.Issue, fromRun bo
 		}
 		_ = rt.store.AppendEvent(existing.TaskID, eventType, detail)
 		if existing.State == core.StateBlocked && !fromRun {
-			_ = rt.rep.ReportBlocked(existing, blockReasonText(blockReasons))
+			rt.reportBlocked(existing, blockReasonText(blockReasons))
 		}
 	}
 	return nil
@@ -402,7 +548,136 @@ func (rt *Runtime) newExecutor() (*executor.Executor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("解析执行超时失败: %w", err)
 	}
-	return executor.New(rt.cfg.Executor.Command, rt.cfg.Executor.Binary, timeout, rt.cfg.Paths.LogDir, rt.secrets.Values)
+	var manager tmux.Manager
+	if tmux.Available("tmux") {
+		tmuxManager, err := tmux.New("tmux")
+		if err != nil {
+			return nil, err
+		}
+		manager = tmuxManager
+	}
+	return executor.New(
+		rt.cfg.Executor.Command,
+		rt.cfg.Executor.Binary,
+		timeout,
+		rt.cfg.Paths.LogDir,
+		filepath.Join(rt.cfg.Paths.AppDir, "var", "results"),
+		rt.secrets.Values,
+		manager,
+	)
+}
+
+func (rt *Runtime) persistExecutionMetrics(task *core.Task, result *executor.Result) error {
+	if task == nil || result == nil {
+		return nil
+	}
+	if result.SessionID == "" && result.CostUSD == 0 && result.Usage == (core.TokenUsage{}) {
+		return nil
+	}
+	if err := rt.store.RecordTokenUsage(storage.TokenUsageRecord{
+		TaskID:     task.TaskID,
+		SessionID:  result.SessionID,
+		Usage:      result.Usage,
+		CostUSD:    result.CostUSD,
+		DurationMS: result.Duration.Milliseconds(),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rt *Runtime) finishTaskExecution(task *core.Task, result *executor.Result, runErr error) error {
+	if task == nil {
+		return nil
+	}
+	if result != nil {
+		if result.SessionID != "" {
+			task.LastSessionID = result.SessionID
+		}
+		if err := rt.persistExecutionMetrics(task, result); err != nil {
+			return err
+		}
+	}
+	if runErr != nil {
+		task.RetryCount++
+		task.ErrorMsg = runErr.Error()
+		task.State = core.StateFailed
+		eventType := core.EventFailed
+		if task.RetryCount >= core.MaxRetry {
+			task.State = core.StateDead
+			eventType = core.EventDead
+		}
+		if err := rt.store.UpsertTask(task); err != nil {
+			return err
+		}
+		_ = rt.store.AppendEvent(task.TaskID, eventType, task.ErrorMsg)
+		rt.reportFailure(task)
+		return nil
+	}
+	task.State = core.StateDone
+	task.ErrorMsg = ""
+	task.ReportPath = filepath.ToSlash(filepath.Join("docs", "reports", core.SafeReportFileName(time.Now(), task.IssueNumber, task.IssueTitle)))
+	if err := rt.store.UpsertTask(task); err != nil {
+		return err
+	}
+	_ = rt.store.AppendEvent(task.TaskID, core.EventDone, "任务执行完成")
+	if result != nil {
+		rt.reportSuccess(task, result.Duration, result.LogFile)
+	}
+	return nil
+}
+
+func (rt *Runtime) finalizePatrolSession(task *core.Task, execEngine *executor.Executor, status tmux.SessionStatus) error {
+	result, resultErr := execEngine.LoadResult(task.TaskID)
+	if result != nil {
+		result.ExitCode = status.ExitCode
+	}
+	if resultErr == nil && status.ExitCode != 0 {
+		resultErr = fmt.Errorf("tmux 会话退出码=%d", status.ExitCode)
+	}
+	return rt.finishTaskExecution(task, result, resultErr)
+}
+
+func (rt *Runtime) finalizeMissingSession(task *core.Task, execEngine *executor.Executor) (bool, error) {
+	result, resultErr := execEngine.LoadResult(task.TaskID)
+	if result == nil && resultErr != nil {
+		return false, nil
+	}
+	return true, rt.finishTaskExecution(task, result, resultErr)
+}
+
+func (rt *Runtime) markTaskDead(task *core.Task, reason, logFile string) error {
+	task.RetryCount++
+	task.ErrorMsg = reason
+	task.State = core.StateDead
+	if err := rt.store.UpsertTask(task); err != nil {
+		return err
+	}
+	_ = rt.store.AppendEvent(task.TaskID, core.EventDead, reason)
+	rt.reportFailure(task)
+	_ = logFile
+	return nil
+}
+
+func (rt *Runtime) reportBlocked(task *core.Task, reason string) {
+	if rt.rep == nil {
+		return
+	}
+	_ = rt.rep.ReportBlocked(task, reason)
+}
+
+func (rt *Runtime) reportFailure(task *core.Task) {
+	if rt.rep == nil {
+		return
+	}
+	_ = rt.rep.ReportFailure(task)
+}
+
+func (rt *Runtime) reportSuccess(task *core.Task, duration time.Duration, logFile string) {
+	if rt.rep == nil {
+		return
+	}
+	_ = rt.rep.ReportSuccess(task, duration, logFile)
 }
 
 type schedulerProbe struct {
@@ -583,22 +858,22 @@ func systemdRepairHint(reason string, installed bool) string {
 	switch {
 	case strings.TrimSpace(reason) == "":
 		if installed {
-			return "请执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer"
+			return "请执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"
 		}
-		return "请检查 user systemd 可用性，并按需执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer"
+		return "请检查 user systemd 可用性，并按需执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"
 	case strings.Contains(reason, "未找到 systemctl"):
 		return "当前环境缺少 systemctl；请安装 systemd 组件，或改用 cron/none"
 	case isUserBusUnavailable(reason):
-		return "请在用户登录会话中执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer；若仍失败，请先确认 user bus 已建立"
+		return "请在用户登录会话中执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer；若仍失败，请先确认 user bus 已建立"
 	case strings.Contains(reason, "is-enabled"), strings.Contains(reason, "disabled"), strings.Contains(reason, "not-found"):
-		return "请执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer"
+		return "请执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"
 	case strings.Contains(reason, "is-active"), strings.Contains(reason, "inactive"), strings.Contains(reason, "failed"):
-		return "请执行 systemctl --user restart ccclaw-ingest.timer ccclaw-run.timer，并检查 journalctl --user -u ccclaw-ingest.service -u ccclaw-run.service"
+		return "请执行 systemctl --user restart ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer，并检查 journalctl --user -u ccclaw-ingest.service -u ccclaw-run.service -u ccclaw-patrol.service"
 	default:
 		if installed {
 			return "请检查 user systemd 状态后重新执行 daemon-reload / enable --now"
 		}
-		return "请检查 user systemd 可用性，并按需执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer"
+		return "请检查 user systemd 可用性，并按需执行 systemctl --user daemon-reload && systemctl --user enable --now ccclaw-ingest.timer ccclaw-run.timer ccclaw-patrol.timer"
 	}
 }
 
@@ -652,6 +927,8 @@ func (rt *Runtime) hasSystemdUnitFiles(unitDir string) bool {
 		"ccclaw-ingest.timer",
 		"ccclaw-run.service",
 		"ccclaw-run.timer",
+		"ccclaw-patrol.service",
+		"ccclaw-patrol.timer",
 	}
 	for _, name := range required {
 		if _, err := os.Stat(filepath.Join(unitDir, name)); err != nil {
@@ -665,7 +942,7 @@ func (rt *Runtime) detectSystemdTimers() (bool, string) {
 	if err := requireCommand("systemctl"); err != nil {
 		return false, err.Error()
 	}
-	units := []string{"ccclaw-ingest.timer", "ccclaw-run.timer"}
+	units := []string{"ccclaw-ingest.timer", "ccclaw-run.timer", "ccclaw-patrol.timer"}
 	for _, unit := range units {
 		if _, err := systemctlUser("is-enabled", unit); err != nil {
 			return false, err.Error()
@@ -674,7 +951,7 @@ func (rt *Runtime) detectSystemdTimers() (bool, string) {
 			return false, err.Error()
 		}
 	}
-	return true, "ccclaw-ingest.timer, ccclaw-run.timer 已启用且运行中"
+	return true, "ccclaw-ingest.timer, ccclaw-run.timer, ccclaw-patrol.timer 已启用且运行中"
 }
 
 func (rt *Runtime) detectCronEntries() (bool, string) {

--- a/src/internal/app/runtime_test.go
+++ b/src/internal/app/runtime_test.go
@@ -1,10 +1,19 @@
 package app
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/41490/ccclaw/internal/adapters/storage"
 	"github.com/41490/ccclaw/internal/config"
+	"github.com/41490/ccclaw/internal/core"
+	"github.com/41490/ccclaw/internal/executor"
 )
 
 func TestParseTargetRepo(t *testing.T) {
@@ -150,5 +159,181 @@ func TestSummarizeSchedulerCronMissingCommand(t *testing.T) {
 	}
 	if want := "repair=当前环境缺少 crontab；请安装 cron/cronie，或改用 systemd/none"; !strings.Contains(detail, want) {
 		t.Fatalf("expected cron repair %q in %q", want, detail)
+	}
+}
+
+func TestStatsRendersSummaryAndTaskTable(t *testing.T) {
+	store, err := storage.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("打开 store 失败: %v", err)
+	}
+	defer store.Close()
+
+	task := &core.Task{
+		TaskID:         "10#body",
+		IdempotencyKey: "10#body",
+		ControlRepo:    "41490/ccclaw",
+		TargetRepo:     "41490/ccclaw",
+		LastSessionID:  "sess-10",
+		IssueNumber:    10,
+		IssueTitle:     "phase1 统计命令",
+		Labels:         []string{"ccclaw"},
+		Intent:         core.IntentResearch,
+		RiskLevel:      core.RiskLow,
+		State:          core.StateDone,
+	}
+	if err := store.UpsertTask(task); err != nil {
+		t.Fatalf("写入任务失败: %v", err)
+	}
+	if err := store.RecordTokenUsage(storage.TokenUsageRecord{
+		TaskID:    task.TaskID,
+		SessionID: "sess-10",
+		Usage: core.TokenUsage{
+			InputTokens:  30,
+			OutputTokens: 12,
+		},
+		CostUSD:    0.09,
+		DurationMS: 5000,
+		RecordedAt: time.Date(2026, 3, 10, 15, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("写入 token 使用失败: %v", err)
+	}
+
+	rt := &Runtime{store: store}
+	var out bytes.Buffer
+	if err := rt.Stats(&out); err != nil {
+		t.Fatalf("执行 stats 失败: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{"执行次数: 1", "会话数: 1", "#10", "sess-10", "累计成本(USD): 0.0900"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in %q", want, text)
+		}
+	}
+}
+
+func TestPatrolFinalizesDeadTMuxSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeBin := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("创建 fake bin 失败: %v", err)
+	}
+	fixtureDir := filepath.Join(tmpDir, "fixture")
+	if err := os.MkdirAll(fixtureDir, 0o755); err != nil {
+		t.Fatalf("创建 fixture 目录失败: %v", err)
+	}
+	tmuxScript := filepath.Join(fakeBin, "tmux")
+	tmuxBody := `#!/usr/bin/env bash
+set -euo pipefail
+fixture_dir="${TMUX_FIXTURE_DIR:?}"
+if [[ "${1:-}" == "list-panes" ]]; then
+  cat "$fixture_dir/list-panes.txt"
+  exit 0
+fi
+if [[ "${1:-}" == "kill-session" ]]; then
+  printf '%s\n' "${3:-}" >> "$fixture_dir/killed.txt"
+  exit 0
+fi
+if [[ "${1:-}" == "capture-pane" ]]; then
+  cat "$fixture_dir/capture.txt"
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(tmuxScript, []byte(tmuxBody), 0o755); err != nil {
+		t.Fatalf("写入 fake tmux 失败: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+oldPath)
+	t.Setenv("TMUX_FIXTURE_DIR", fixtureDir)
+
+	stateDB := filepath.Join(tmpDir, "state.db")
+	store, err := storage.Open(stateDB)
+	if err != nil {
+		t.Fatalf("打开 store 失败: %v", err)
+	}
+
+	task := &core.Task{
+		TaskID:         "10#body",
+		IdempotencyKey: "10#body",
+		ControlRepo:    "41490/ccclaw",
+		TargetRepo:     "41490/ccclaw",
+		IssueNumber:    10,
+		IssueTitle:     "tmux patrol",
+		Labels:         []string{"ccclaw"},
+		Intent:         core.IntentResearch,
+		RiskLevel:      core.RiskLow,
+		State:          core.StateRunning,
+	}
+	if err := store.UpsertTask(task); err != nil {
+		t.Fatalf("写入任务失败: %v", err)
+	}
+
+	sessionName := executor.SessionName(task.TaskID)
+	if err := os.WriteFile(filepath.Join(fixtureDir, "list-panes.txt"), []byte(sessionName+"\t"+strconv.FormatInt(time.Now().Add(-time.Minute).Unix(), 10)+"\t1\t0\t123\n"), 0o644); err != nil {
+		t.Fatalf("写入 list-panes fixture 失败: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fixtureDir, "capture.txt"), []byte(""), 0o644); err != nil {
+		t.Fatalf("写入 capture fixture 失败: %v", err)
+	}
+
+	resultDir := filepath.Join(tmpDir, "app", "var", "results")
+	if err := os.MkdirAll(resultDir, 0o755); err != nil {
+		t.Fatalf("创建结果目录失败: %v", err)
+	}
+	resultPath := filepath.Join(resultDir, "10_body.json")
+	resultJSON := `{"type":"result","subtype":"success","session_id":"sess-10","duration_ms":2000,"result":"任务完成","total_cost_usd":0.15,"usage":{"input_tokens":50,"output_tokens":20}}`
+	if err := os.WriteFile(resultPath, []byte(resultJSON), 0o644); err != nil {
+		t.Fatalf("写入结果文件失败: %v", err)
+	}
+
+	logDir := filepath.Join(tmpDir, "app", "log")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("创建日志目录失败: %v", err)
+	}
+	rt := &Runtime{
+		cfg: &config.Config{
+			Paths: config.PathsConfig{
+				AppDir:  filepath.Join(tmpDir, "app"),
+				LogDir:  logDir,
+				StateDB: stateDB,
+				KBDir:   "/opt/ccclaw/kb",
+			},
+			Executor: config.ExecutorConfig{
+				Command: []string{"/bin/sh"},
+				Timeout: "30m",
+			},
+		},
+		secrets: &config.Secrets{Values: map[string]string{}},
+		store:   store,
+	}
+
+	var out bytes.Buffer
+	if err := rt.Patrol(context.Background(), &out); err != nil {
+		t.Fatalf("执行 patrol 失败: %v", err)
+	}
+	if !strings.Contains(out.String(), "completed=1") {
+		t.Fatalf("unexpected patrol output: %q", out.String())
+	}
+
+	store, err = storage.Open(stateDB)
+	if err != nil {
+		t.Fatalf("重新打开 store 失败: %v", err)
+	}
+	defer store.Close()
+	loaded, err := store.GetByIdempotency(task.IdempotencyKey)
+	if err != nil {
+		t.Fatalf("读取任务失败: %v", err)
+	}
+	if loaded == nil || loaded.State != core.StateDone || loaded.LastSessionID != "sess-10" {
+		t.Fatalf("unexpected task after patrol: %#v", loaded)
+	}
+	summary, err := store.TokenStats()
+	if err != nil {
+		t.Fatalf("读取 token 汇总失败: %v", err)
+	}
+	if summary.Runs != 1 || summary.InputTokens != 50 {
+		t.Fatalf("unexpected summary after patrol: %#v", summary)
 	}
 }

--- a/src/internal/core/task.go
+++ b/src/internal/core/task.go
@@ -27,6 +27,7 @@ const (
 	EventDone    EventType = "DONE"
 	EventDead    EventType = "DEAD"
 	EventUpdated EventType = "UPDATED"
+	EventWarning EventType = "WARNING"
 )
 
 type RiskLevel string
@@ -53,6 +54,7 @@ type Task struct {
 	IdempotencyKey        string
 	ControlRepo           string
 	TargetRepo            string
+	LastSessionID         string
 	IssueNumber           int
 	IssueTitle            string
 	IssueBody             string
@@ -71,6 +73,13 @@ type Task struct {
 	ReportPath            string
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
+}
+
+type TokenUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
 func IdempotencyKey(issueNumber int) string {

--- a/src/internal/executor/executor.go
+++ b/src/internal/executor/executor.go
@@ -3,30 +3,43 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/41490/ccclaw/internal/core"
+	"github.com/41490/ccclaw/internal/tmux"
 )
 
 type Result struct {
-	Output   string
-	ExitCode int
-	Duration time.Duration
-	LogFile  string
+	Output      string
+	ExitCode    int
+	Duration    time.Duration
+	LogFile     string
+	ResultFile  string
+	SessionID   string
+	SessionName string
+	CostUSD     float64
+	Usage       core.TokenUsage
+	Pending     bool
 }
 
 type Executor struct {
-	command []string
-	timeout time.Duration
-	logDir  string
-	secrets map[string]string
+	command     []string
+	timeout     time.Duration
+	logDir      string
+	resultDir   string
+	secrets     map[string]string
+	tmuxManager tmux.Manager
 }
 
-func New(command []string, binary string, timeout time.Duration, logDir string, secrets map[string]string) (*Executor, error) {
+func New(command []string, binary string, timeout time.Duration, logDir, resultDir string, secrets map[string]string, tmuxManager tmux.Manager) (*Executor, error) {
 	resolved := make([]string, 0, len(command))
 	for _, item := range command {
 		if strings.TrimSpace(item) != "" {
@@ -45,15 +58,97 @@ func New(command []string, binary string, timeout time.Duration, logDir string, 
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return nil, fmt.Errorf("创建日志目录失败: %w", err)
 	}
-	return &Executor{command: resolved, timeout: timeout, logDir: logDir, secrets: copyMap(secrets)}, nil
+	if err := os.MkdirAll(resultDir, 0o755); err != nil {
+		return nil, fmt.Errorf("创建结果目录失败: %w", err)
+	}
+	return &Executor{
+		command:     resolved,
+		timeout:     timeout,
+		logDir:      logDir,
+		resultDir:   resultDir,
+		secrets:     copyMap(secrets),
+		tmuxManager: tmuxManager,
+	}, nil
 }
 
 func (e *Executor) Run(parent context.Context, repoPath, taskID, prompt string) (*Result, error) {
+	if e.tmuxManager != nil {
+		return e.launchTMux(repoPath, taskID, prompt)
+	}
+	return e.runSync(parent, repoPath, taskID, prompt)
+}
+
+func (e *Executor) ArtifactPaths(taskID string) Result {
+	safe := safeTaskID(taskID)
+	return Result{
+		SessionName: sessionName(taskID),
+		LogFile:     filepath.Join(e.logDir, safe+".log"),
+		ResultFile:  filepath.Join(e.resultDir, safe+".json"),
+	}
+}
+
+func (e *Executor) LoadResult(taskID string) (*Result, error) {
+	artifacts := e.ArtifactPaths(taskID)
+	payload, err := os.ReadFile(artifacts.ResultFile)
+	if err != nil {
+		return nil, fmt.Errorf("读取结果文件失败: %w", err)
+	}
+	result, parseErr := parseClaudeResult(payload, 0, artifacts.LogFile, artifacts.ResultFile)
+	if result != nil {
+		result.SessionName = artifacts.SessionName
+		result.LogFile = artifacts.LogFile
+		result.ResultFile = artifacts.ResultFile
+	}
+	return result, parseErr
+}
+
+func (e *Executor) Timeout() time.Duration {
+	return e.timeout
+}
+
+func (e *Executor) TMux() tmux.Manager {
+	return e.tmuxManager
+}
+
+func (e *Executor) launchTMux(repoPath, taskID, prompt string) (*Result, error) {
+	artifacts := e.ArtifactPaths(taskID)
+	if err := os.Remove(artifacts.LogFile); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("清理旧日志失败: %w", err)
+	}
+	if err := os.Remove(artifacts.ResultFile); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("清理旧结果失败: %w", err)
+	}
+	launchCommand := e.buildTMuxCommand(prompt, artifacts.ResultFile)
+	if err := e.tmuxManager.Launch(tmux.SessionSpec{
+		Name:    artifacts.SessionName,
+		WorkDir: repoPath,
+		Command: launchCommand,
+		LogFile: artifacts.LogFile,
+	}); err != nil {
+		return nil, fmt.Errorf("启动 tmux 会话失败: %w", err)
+	}
+	artifacts.Pending = true
+	return &artifacts, nil
+}
+
+func (e *Executor) buildTMuxCommand(prompt, resultFile string) string {
+	args := append([]string{}, e.command...)
+	args = append(args,
+		"-p", prompt,
+		"--dangerously-skip-permissions",
+		"--output-format", "json",
+	)
+	commandLine := shellJoin(args)
+	script := fmt.Sprintf("set -o pipefail; %s | tee %s", commandLine, shellQuote(resultFile))
+	return fmt.Sprintf("bash -lc %s", shellQuote(script))
+}
+
+func (e *Executor) runSync(parent context.Context, repoPath, taskID, prompt string) (*Result, error) {
 	ctx, cancel := context.WithTimeout(parent, e.timeout)
 	defer cancel()
 
-	safe := strings.NewReplacer("#", "_", "/", "_").Replace(taskID)
-	logFile := filepath.Join(e.logDir, fmt.Sprintf("%s_%d.log", safe, time.Now().Unix()))
+	artifacts := e.ArtifactPaths(taskID)
+	logFile := filepath.Join(e.logDir, fmt.Sprintf("%s_%d.log", safeTaskID(taskID), time.Now().Unix()))
 	logHandle, err := os.Create(logFile)
 	if err != nil {
 		return nil, fmt.Errorf("创建日志文件失败: %w", err)
@@ -64,29 +159,137 @@ func (e *Executor) Run(parent context.Context, repoPath, taskID, prompt string) 
 	args = append(args,
 		"-p", prompt,
 		"--dangerously-skip-permissions",
-		"--output-format", "text",
+		"--output-format", "json",
 	)
 	cmd := exec.CommandContext(ctx, e.command[0], args...)
 	cmd.Dir = repoPath
 	cmd.Env = append(cmd.Environ(), mapToEnv(e.secrets)...)
 
-	var output bytes.Buffer
-	writer := io.MultiWriter(logHandle, &output)
-	cmd.Stdout = writer
-	cmd.Stderr = writer
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(logHandle, &stdout)
+	cmd.Stderr = io.MultiWriter(logHandle, &stderr)
 
 	start := time.Now()
 	runErr := cmd.Run()
 	duration := time.Since(start)
 	exitCode := 0
+	result, parseErr := parseClaudeResult(stdout.Bytes(), duration, logFile, artifacts.ResultFile)
 	if runErr != nil {
 		exitCode = 1
 		if exitErr, ok := runErr.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		}
-		return &Result{Output: output.String(), ExitCode: exitCode, Duration: duration, LogFile: logFile}, fmt.Errorf("执行器运行失败: %w", runErr)
+		if result == nil {
+			result = &Result{Output: strings.TrimSpace(stdout.String() + stderr.String()), Duration: duration, LogFile: logFile}
+		}
+		result.ExitCode = exitCode
+		if parseErr != nil {
+			return result, fmt.Errorf("执行器运行失败: %w；结果校验失败: %v", runErr, parseErr)
+		}
+		return result, fmt.Errorf("执行器运行失败: %w", runErr)
 	}
-	return &Result{Output: output.String(), ExitCode: exitCode, Duration: duration, LogFile: logFile}, nil
+	if parseErr != nil {
+		if result != nil {
+			result.ExitCode = exitCode
+			return result, parseErr
+		}
+		return &Result{
+			Output:   strings.TrimSpace(stdout.String() + stderr.String()),
+			ExitCode: exitCode,
+			Duration: duration,
+			LogFile:  logFile,
+		}, fmt.Errorf("解析 Claude JSON 输出失败: %w", parseErr)
+	}
+	result.ExitCode = exitCode
+	return result, nil
+}
+
+type claudeJSONResult struct {
+	Type         string          `json:"type"`
+	Subtype      string          `json:"subtype"`
+	SessionID    string          `json:"session_id"`
+	IsError      bool            `json:"is_error"`
+	DurationMS   int64           `json:"duration_ms"`
+	Result       string          `json:"result"`
+	TotalCostUSD float64         `json:"total_cost_usd"`
+	Usage        core.TokenUsage `json:"usage"`
+}
+
+func parseClaudeResult(raw []byte, duration time.Duration, logFile, resultFile string) (*Result, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("stdout 为空")
+	}
+	var payload claudeJSONResult
+	if err := json.Unmarshal(trimmed, &payload); err != nil {
+		return nil, err
+	}
+	result := &Result{
+		Output:     payload.Result,
+		Duration:   duration,
+		LogFile:    logFile,
+		ResultFile: resultFile,
+		SessionID:  payload.SessionID,
+		CostUSD:    payload.TotalCostUSD,
+		Usage:      payload.Usage,
+	}
+	if payload.DurationMS > 0 {
+		result.Duration = time.Duration(payload.DurationMS) * time.Millisecond
+	}
+	if payload.IsError || strings.HasPrefix(payload.Subtype, "error_") {
+		if payload.Subtype == "" {
+			return result, fmt.Errorf("Claude 返回错误结果")
+		}
+		return result, fmt.Errorf("Claude 返回错误结果: %s", payload.Subtype)
+	}
+	if payload.Type != "" && payload.Type != "result" {
+		return result, fmt.Errorf("Claude 返回了非 result 类型: %s", payload.Type)
+	}
+	if result.SessionID == "" && result.Output == "" && result.CostUSD == 0 {
+		return result, fmt.Errorf("Claude JSON 输出缺少有效结果")
+	}
+	return result, nil
+}
+
+func SessionName(taskID string) string {
+	return sessionName(taskID)
+}
+
+func sessionName(taskID string) string {
+	checksum := 0
+	for idx, r := range taskID {
+		checksum += (idx + 1) * int(r)
+	}
+	return fmt.Sprintf("ccclaw-%s-%04x", safeTaskID(taskID), checksum&0xffff)
+}
+
+func safeTaskID(taskID string) string {
+	replacer := strings.NewReplacer("#", "_", "/", "_", ":", "_", ".", "_", " ", "_")
+	return replacer.Replace(taskID)
+}
+
+func shellJoin(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func ParseExitCode(text string) int {
+	code, err := strconv.Atoi(strings.TrimSpace(text))
+	if err != nil {
+		return 0
+	}
+	return code
 }
 
 func mapToEnv(values map[string]string) []string {

--- a/src/internal/executor/executor_test.go
+++ b/src/internal/executor/executor_test.go
@@ -1,0 +1,110 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/41490/ccclaw/internal/tmux"
+)
+
+type fakeTMuxManager struct {
+	spec tmux.SessionSpec
+}
+
+func (f *fakeTMuxManager) Launch(spec tmux.SessionSpec) error {
+	f.spec = spec
+	return nil
+}
+
+func (f *fakeTMuxManager) Status(name string) (*tmux.SessionStatus, error) { return nil, nil }
+func (f *fakeTMuxManager) CaptureOutput(name string, lines int) (string, error) {
+	return "", nil
+}
+func (f *fakeTMuxManager) Kill(name string) error { return nil }
+func (f *fakeTMuxManager) List(prefix string) ([]tmux.SessionStatus, error) {
+	return nil, nil
+}
+
+func TestExecutorRunParsesJSONResult(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "fake-claude.sh")
+	script := "#!/bin/sh\ncat <<'EOF'\n{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"sess-1\",\"result\":\"任务完成\",\"total_cost_usd\":0.125,\"usage\":{\"input_tokens\":12,\"output_tokens\":8,\"cache_creation_input_tokens\":3,\"cache_read_input_tokens\":4}}\nEOF\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("写入脚本失败: %v", err)
+	}
+	execEngine, err := New([]string{scriptPath}, "", time.Minute, filepath.Join(tmpDir, "log"), filepath.Join(tmpDir, "result"), nil, nil)
+	if err != nil {
+		t.Fatalf("创建执行器失败: %v", err)
+	}
+
+	result, err := execEngine.Run(context.Background(), tmpDir, "10#body", "test prompt")
+	if err != nil {
+		t.Fatalf("执行器运行失败: %v", err)
+	}
+	if result.SessionID != "sess-1" {
+		t.Fatalf("unexpected session id: %q", result.SessionID)
+	}
+	if result.CostUSD != 0.125 {
+		t.Fatalf("unexpected cost: %v", result.CostUSD)
+	}
+	if result.Usage.InputTokens != 12 || result.Usage.OutputTokens != 8 {
+		t.Fatalf("unexpected usage: %#v", result.Usage)
+	}
+	if result.Output != "任务完成" {
+		t.Fatalf("unexpected result output: %q", result.Output)
+	}
+}
+
+func TestExecutorRunReturnsStructuredErrorResult(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "fake-claude-error.sh")
+	script := "#!/bin/sh\ncat <<'EOF'\n{\"type\":\"result\",\"subtype\":\"error_max_turns\",\"session_id\":\"sess-error\",\"result\":\"达到上限\",\"is_error\":true,\"total_cost_usd\":0.5,\"usage\":{\"input_tokens\":20,\"output_tokens\":10}}\nEOF\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("写入脚本失败: %v", err)
+	}
+	execEngine, err := New([]string{scriptPath}, "", time.Minute, filepath.Join(tmpDir, "log"), filepath.Join(tmpDir, "result"), nil, nil)
+	if err != nil {
+		t.Fatalf("创建执行器失败: %v", err)
+	}
+
+	result, runErr := execEngine.Run(context.Background(), tmpDir, "10#body", "test prompt")
+	if runErr == nil {
+		t.Fatal("预期返回结构化错误")
+	}
+	if !strings.Contains(runErr.Error(), "error_max_turns") {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if result == nil || result.SessionID != "sess-error" {
+		t.Fatalf("预期保留 session_id，实际为 %#v", result)
+	}
+	if result.CostUSD != 0.5 {
+		t.Fatalf("unexpected cost: %v", result.CostUSD)
+	}
+}
+
+func TestExecutorRunLaunchesTMuxSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	manager := &fakeTMuxManager{}
+	execEngine, err := New([]string{"sh"}, "", time.Minute, filepath.Join(tmpDir, "log"), filepath.Join(tmpDir, "result"), nil, manager)
+	if err != nil {
+		t.Fatalf("创建执行器失败: %v", err)
+	}
+
+	result, runErr := execEngine.Run(context.Background(), tmpDir, "10#body", "test prompt")
+	if runErr != nil {
+		t.Fatalf("tmux launch 失败: %v", runErr)
+	}
+	if result == nil || !result.Pending {
+		t.Fatalf("预期返回 pending 结果，实际为 %#v", result)
+	}
+	if !strings.Contains(manager.spec.Command, "--output-format") || !strings.Contains(manager.spec.Command, "json") {
+		t.Fatalf("预期 tmux 命令包含 json 输出，实际为 %q", manager.spec.Command)
+	}
+	if manager.spec.Name == "" || !strings.HasPrefix(manager.spec.Name, "ccclaw-") {
+		t.Fatalf("unexpected session name: %#v", manager.spec)
+	}
+}

--- a/src/internal/tmux/manager.go
+++ b/src/internal/tmux/manager.go
@@ -1,0 +1,217 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var ErrSessionNotFound = errors.New("tmux 会话不存在")
+
+type SessionSpec struct {
+	Name    string
+	WorkDir string
+	Command string
+	LogFile string
+}
+
+type SessionStatus struct {
+	Name      string
+	CreatedAt time.Time
+	PaneDead  bool
+	ExitCode  int
+	PanePID   int
+}
+
+type Manager interface {
+	Launch(spec SessionSpec) error
+	Status(name string) (*SessionStatus, error)
+	CaptureOutput(name string, lines int) (string, error)
+	Kill(name string) error
+	List(prefix string) ([]SessionStatus, error)
+}
+
+type ExecManager struct {
+	binary string
+}
+
+func Available(binary string) bool {
+	if binary == "" {
+		binary = "tmux"
+	}
+	_, err := exec.LookPath(binary)
+	return err == nil
+}
+
+func New(binary string) (*ExecManager, error) {
+	if binary == "" {
+		binary = "tmux"
+	}
+	if _, err := exec.LookPath(binary); err != nil {
+		return nil, fmt.Errorf("未找到 tmux: %w", err)
+	}
+	return &ExecManager{binary: binary}, nil
+}
+
+func (m *ExecManager) Launch(spec SessionSpec) error {
+	if spec.Name == "" {
+		return errors.New("tmux session name 不能为空")
+	}
+	if spec.WorkDir == "" {
+		return errors.New("tmux workdir 不能为空")
+	}
+	if spec.Command == "" {
+		return errors.New("tmux command 不能为空")
+	}
+	if _, err := m.run("new-session", "-d", "-s", spec.Name, "-c", spec.WorkDir); err != nil {
+		return err
+	}
+	if _, err := m.run("set-option", "-t", spec.Name, "remain-on-exit", "on"); err != nil {
+		return err
+	}
+	if _, err := m.run("set-option", "-t", spec.Name, "history-limit", "50000"); err != nil {
+		return err
+	}
+	if strings.TrimSpace(spec.LogFile) != "" {
+		pipeCommand := fmt.Sprintf("cat >> %s", shellQuote(spec.LogFile))
+		if _, err := m.run("pipe-pane", "-t", spec.Name, "-o", pipeCommand); err != nil {
+			return err
+		}
+	}
+	if _, err := m.run("send-keys", "-t", spec.Name, spec.Command, "Enter"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ExecManager) Status(name string) (*SessionStatus, error) {
+	output, err := m.run("list-panes", "-t", name, "-F", "#{session_name}\t#{session_created}\t#{pane_dead}\t#{pane_dead_status}\t#{pane_pid}")
+	if err != nil {
+		if isMissingSession(err) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, err
+	}
+	items, err := parseStatuses(output)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, ErrSessionNotFound
+	}
+	return &items[0], nil
+}
+
+func (m *ExecManager) CaptureOutput(name string, lines int) (string, error) {
+	if lines <= 0 {
+		lines = 200
+	}
+	output, err := m.run("capture-pane", "-p", "-t", name, "-S", fmt.Sprintf("-%d", lines))
+	if err != nil {
+		if isMissingSession(err) {
+			return "", ErrSessionNotFound
+		}
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func (m *ExecManager) Kill(name string) error {
+	_, err := m.run("kill-session", "-t", name)
+	if err != nil && isMissingSession(err) {
+		return nil
+	}
+	return err
+}
+
+func (m *ExecManager) List(prefix string) ([]SessionStatus, error) {
+	output, err := m.run("list-panes", "-a", "-F", "#{session_name}\t#{session_created}\t#{pane_dead}\t#{pane_dead_status}\t#{pane_pid}")
+	if err != nil {
+		if isNoServer(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	items, err := parseStatuses(output)
+	if err != nil {
+		return nil, err
+	}
+	if prefix == "" {
+		return items, nil
+	}
+	filtered := make([]SessionStatus, 0, len(items))
+	for _, item := range items {
+		if strings.HasPrefix(item.Name, prefix) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered, nil
+}
+
+func (m *ExecManager) run(args ...string) (string, error) {
+	cmd := exec.Command(m.binary, args...)
+	output, err := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(output))
+	if err != nil {
+		if text == "" {
+			text = err.Error()
+		}
+		return "", fmt.Errorf("tmux %s 失败: %s", strings.Join(args, " "), text)
+	}
+	return text, nil
+}
+
+func parseStatuses(raw string) ([]SessionStatus, error) {
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	statuses := make([]SessionStatus, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) != 5 {
+			return nil, fmt.Errorf("无法解析 tmux 状态行: %s", line)
+		}
+		createdUnix, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("解析 tmux created_at 失败: %w", err)
+		}
+		exitCode, err := strconv.Atoi(parts[3])
+		if err != nil {
+			return nil, fmt.Errorf("解析 tmux exit code 失败: %w", err)
+		}
+		panePID, err := strconv.Atoi(parts[4])
+		if err != nil {
+			return nil, fmt.Errorf("解析 tmux pane pid 失败: %w", err)
+		}
+		statuses = append(statuses, SessionStatus{
+			Name:      parts[0],
+			CreatedAt: time.Unix(createdUnix, 0),
+			PaneDead:  parts[2] == "1",
+			ExitCode:  exitCode,
+			PanePID:   panePID,
+		})
+	}
+	return statuses, nil
+}
+
+func isMissingSession(err error) bool {
+	text := err.Error()
+	return strings.Contains(text, "can't find session") || strings.Contains(text, "找不到 session")
+}
+
+func isNoServer(err error) bool {
+	text := err.Error()
+	return strings.Contains(text, "no server running") || strings.Contains(text, "没有正在运行的 server")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}

--- a/src/ops/systemd/ccclaw-patrol.service
+++ b/src/ops/systemd/ccclaw-patrol.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=ccclaw patrol service (user)
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.ccclaw
+ExecStart=%h/.ccclaw/bin/ccclaw patrol --config %h/.ccclaw/ops/config/config.toml --env-file %h/.ccclaw/.env

--- a/src/ops/systemd/ccclaw-patrol.timer
+++ b/src/ops/systemd/ccclaw-patrol.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run ccclaw patrol every 2 minutes (user)
+
+[Timer]
+OnCalendar=*:0/2
+Persistent=true
+Unit=ccclaw-patrol.service
+
+[Install]
+WantedBy=timers.target

--- a/src/tests/install_regression.sh
+++ b/src/tests/install_regression.sh
@@ -157,6 +157,8 @@ test_first_install_and_idempotent_reinstall() {
   assert_file_missing "$xdg/systemd/user/ccclaw-ingest.timer"
   assert_file_missing "$xdg/systemd/user/ccclaw-run.service"
   assert_file_missing "$xdg/systemd/user/ccclaw-run.timer"
+  assert_file_missing "$xdg/systemd/user/ccclaw-patrol.service"
+  assert_file_missing "$xdg/systemd/user/ccclaw-patrol.timer"
   assert_contains "$config_file" "repo = '41490/task-local'"
   assert_contains "$config_file" "local_path = '$task_repo'"
   assert_contains "$config_file" "default_target = '41490/task-local'"


### PR DESCRIPTION
## 变更
- 落地 Issue #10 Phase 1：Claude JSON 结果解析、token_usage 落库、ccclaw stats
- 落地 Issue #10 Phase 2：tmux 异步执行、ccclaw patrol、patrol systemd unit
- 同步 install/upgrade/dist 回归链路与工程报告

## 验证
- /usr/local/go/bin/go test ./...
- make -C src dist-sync GO=/usr/local/go/bin/go GOFMT=/usr/local/go/bin/gofmt
- bash src/tests/install_regression.sh